### PR TITLE
Add the ability to add an alarm action specifically for scale up events

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ No modules.
 | <a name="input_scale_target_max_capacity"></a> [scale\_target\_max\_capacity](#input\_scale\_target\_max\_capacity) | The max capacity of the scalable target | `number` | `5` | no |
 | <a name="input_scale_target_min_capacity"></a> [scale\_target\_min\_capacity](#input\_scale\_target\_min\_capacity) | The min capacity of the scalable target | `number` | `1` | no |
 | <a name="input_sns_topic_arn"></a> [sns\_topic\_arn](#input\_sns\_topic\_arn) | The ARN of an SNS topic to send notifications on alarm actions. | `string` | `""` | no |
+| <a name="high_cpu_sns_topic_arn"></a> [high\ cpu\ sns\_topic\_arn](#input\_high\_cpu\_sns\_topic\_arn) | The ARN of an SNS topic to send notifications specifically on high CPU alarm actions. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resource tags | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ No modules.
 | <a name="input_scale_target_max_capacity"></a> [scale\_target\_max\_capacity](#input\_scale\_target\_max\_capacity) | The max capacity of the scalable target | `number` | `5` | no |
 | <a name="input_scale_target_min_capacity"></a> [scale\_target\_min\_capacity](#input\_scale\_target\_min\_capacity) | The min capacity of the scalable target | `number` | `1` | no |
 | <a name="input_sns_topic_arn"></a> [sns\_topic\_arn](#input\_sns\_topic\_arn) | The ARN of an SNS topic to send notifications on alarm actions. | `string` | `""` | no |
-| <a name="high_cpu_sns_topic_arn"></a> [high\ cpu\ sns\_topic\_arn](#input\_high\_cpu\_sns\_topic\_arn) | The ARN of an SNS topic to send notifications specifically on high CPU alarm actions. | `string` | `""` | no |
+| <a name="high_cpu_sns_topic_arn"></a> [high\_cpu\_sns\_topic\_arn](#input\_high\_cpu\_sns\_topic\_arn) | The ARN of an SNS topic to send notifications specifically on high CPU alarm actions. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resource tags | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_high" {
   }
   alarm_actions = compact([
     aws_appautoscaling_policy.scale_up_policy.arn,
-    var.sns_topic_arn != "" || var.high_cpu_sns_topic_arn != "" coalesce(var.sns_topic_arn, var.high_cpu_sns_topic_arn, "") : ""
+    var.sns_topic_arn != "" || var.high_cpu_sns_topic_arn != "" ? coalesce(var.sns_topic_arn, var.high_cpu_sns_topic_arn, "") : ""
   ])
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_high" {
   }
   alarm_actions = compact([
     aws_appautoscaling_policy.scale_up_policy.arn,
-    var.sns_topic_arn != "" ? var.sns_topic_arn : ""
+    coalesce(var.sns_topic_arn, var.high_cpu_sns_topic_arn, "")
   ])
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_high" {
   }
   alarm_actions = compact([
     aws_appautoscaling_policy.scale_up_policy.arn,
-    coalesce(var.sns_topic_arn, var.high_cpu_sns_topic_arn, "")
+    var.sns_topic_arn != "" || var.high_cpu_sns_topic_arn != "" coalesce(var.sns_topic_arn, var.high_cpu_sns_topic_arn, "") : ""
   ])
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,13 @@ variable "scale_target_min_capacity" {
   type        = number
 }
 
+variable "high_cpu_sns_topic_arn" {
+  # Optional ARN of an SNS topic for sending notifications for a high CPU alarm
+  type        = string
+  description = "The ARN of an SNS topic to send notifications on high CPU alarm actions."
+  default     = "" # Set an empty string as default to avoid potential errors
+}
+
 variable "sns_topic_arn" {
   # Optional ARN of an SNS topic for sending notifications
   type        = string


### PR DESCRIPTION
Including alarm actions for both high and low CPU alarms can get really noisy. We'd like the ability to set an alarm action specifically for scale up events. This PR creates a new variable for that and uses it specifically for aws_cloudwatch_metric_alarm. README is updated with this change.

https://github.com/civiform/civiform/issues/11269